### PR TITLE
Replaces CSV input files with JSON-format files

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -11,24 +11,17 @@ import { switchPod } from './main.js'
 import { switchArea } from './main.js'
 import { toggleHsa } from './main.js'
 
-const selectedArea = 'E08000026'
-const selectedProjVar = '1'
-const selectedHorizon = '2025'
-const selectedPod = 'aae'
+let selectedArea = 'E08000026'
 
-const data = await d3.csv(blobDir + filePrefix + selectedArea + fileExt)
+let data = await d3.json(blobDir + filePrefix + selectedArea + fileExt)
 
-const grpDat = d3.group(
-  data,
-  (d) => d.proj_id,
-  (d) => d.end_year,
-  (d) => d.pod
+let projDat = data.filter(
+  item => (
+    item.proj_id == '1' &&
+    item.end_year == '2025' &&
+    item.pod == 'aae'
+  )
 )
-
-const projDat = grpDat
-  .get(selectedProjVar)
-  .get(selectedHorizon)
-  .get(selectedPod)
 
 plotHsaGrps(projDat)
 
@@ -57,7 +50,7 @@ d3.select('#selectHorizon').on('change', function () {
   let selectedHorizon = d3.select(this).property('value')
   let selectedProjVar = d3.select('#selectProjVar').property('value')
   let selectedPod = d3.select('#selectPod').property('value')
-  updatePlots(grpDat, selectedProjVar, selectedHorizon, selectedPod)
+  updatePlots(data, selectedProjVar, selectedHorizon, selectedPod)
 })
 
 /* when the projection variant dropdown changes, run updatePlots() with the new value */
@@ -65,7 +58,7 @@ d3.select('#selectProjVar').on('change', function () {
   let selectedProjVar = d3.select(this).property('value')
   let selectedHorizon = d3.select('#selectHorizon').property('value')
   let selectedPod = d3.select('#selectPod').property('value')
-  updatePlots(grpDat, selectedProjVar, selectedHorizon, selectedPod)
+  updatePlots(data, selectedProjVar, selectedHorizon, selectedPod)
 })
 
 /* when the health status toggle changes show/hide circles */


### PR DESCRIPTION
Previously, input data for the app was loaded from .csv files. This worked but the .csv files for each area were very large c.65MB with results from 1000 model runs per combination of variant / hsagrp / horizon (1000 x 11 x 13 x 4 = 572k rows). I had already limited the input files to 4 model horizons (2025, 2030, 2035, and 2040) from a possible 24 (2020 to 2043).

Inside the app, I used `d3.bin` [https://d3js.org/d3-array/bin](url) to bin the model result values into intervals before plotting histograms. This worked fine but by pre-calculating the binning I should be able to shrink the input datasets. JSON-format seemed like a more natural approach than sticking with CSVs.

For the same number of model runs the JSON files are <500KB unformatted and c.700KB after formatting with [prettier](https://prettier.io/).